### PR TITLE
Initial update for Spring 2020 (style)

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -13,9 +13,7 @@
     ]]></description>
 
   <change-notes><![CDATA[
-      First version without the old version of the Java Visualizer.
-      For the updated (and now separate) Java Visualizer, see: https://plugins.jetbrains.com/plugin/11512-java-visualizer
-      Automated style configuration update.
+      Update style checker for Spring 2020 (Paul Hilfinger).
     ]]>
   </change-notes>
 

--- a/resources/style_config/index.txt
+++ b/resources/style_config/index.txt
@@ -7,6 +7,7 @@
 
 
 # Hilfinger semesters:
+sp20	cs61b_fa18_checks.xml	cs61b_fa18_suppressions.xml
 fa18	cs61b_fa18_checks.xml	cs61b_fa18_suppressions.xml
 fa17	cs61b_fa17_checks.xml	cs61b_fa17_suppressions.xml
 fa\d+	cs61b_fa18_checks.xml	cs61b_fa18_suppressions.xml


### PR DESCRIPTION
Not sure if the style rules have been updated from Fall 2018 -- I don't have access to the cs61b-software repository without an instructional account [ :( ].

Shouldn't be merged until the new(?) style rules are confirmed.

I guess this PR also serves as the de facto guide for updating the plugin (which usually doesn't have to be done, unless style rules change, or the normal PNH Fall, Hug Spring gets switched up).