### PR TITLE
Fix IntelliJ platform version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ pluginVersion = 2.0.8
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 213
-pluginUntilBuild = 222.*
+pluginUntilBuild = 223.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#intellij-extension
 platformType = IC


### PR DESCRIPTION
Plugin does not load on latest version of IntelliJ. The marketplace shows an older version. This change fixes it.