### PR TITLE
Deprecate fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ## [Unreleased]
 
-## [2.0.14]
+## [2.0.15]
 
 ### Changed
 
-- Spring 2024 style checker
+- Update deprecated ActionUpdateThread

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 pluginGroup = edu.berkeley.cs61b.plugin
 pluginName = CS 61B
 # SemVer format -> https://semver.org
-pluginVersion = 2.0.14
+pluginVersion = 2.0.15
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 213

--- a/src/main/java/edu/berkeley/cs61b/plugin/CheckStyleAction.java
+++ b/src/main/java/edu/berkeley/cs61b/plugin/CheckStyleAction.java
@@ -1,8 +1,24 @@
 package edu.berkeley.cs61b.plugin;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.jetbrains.annotations.NotNull;
+import org.xml.sax.InputSource;
+
 import com.intellij.execution.filters.OpenFileHyperlinkInfo;
 import com.intellij.execution.ui.ConsoleView;
 import com.intellij.execution.ui.ConsoleViewContentType;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
@@ -20,19 +36,6 @@ import com.puppycrawl.tools.checkstyle.PropertiesExpander;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.AuditListener;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
-import org.xml.sax.InputSource;
-
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
 
 public class CheckStyleAction extends AnAction {
 	private static final String CONFIG_ROOT = "style_config/";
@@ -82,6 +85,11 @@ public class CheckStyleAction extends AnAction {
 				runCheckStyle(project, consoleView, checkerFiles);
 			});
 		}
+	}
+
+	@Override
+	public @NotNull ActionUpdateThread getActionUpdateThread() {
+		return ActionUpdateThread.BGT;
 	}
 
 	private void collectFiles(VirtualFile[] parent, List<File> list) {

--- a/src/main/java/edu/berkeley/cs61b/plugin/SettingsAction.java
+++ b/src/main/java/edu/berkeley/cs61b/plugin/SettingsAction.java
@@ -1,10 +1,12 @@
 package edu.berkeley.cs61b.plugin;
 
+import org.jetbrains.annotations.NotNull;
+
 import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.ui.DialogWrapper;
-import org.jetbrains.annotations.NotNull;
 
 public class SettingsAction extends AnAction {
 	@Override
@@ -18,5 +20,10 @@ public class SettingsAction extends AnAction {
 		if (form.getExitCode() == DialogWrapper.OK_EXIT_CODE) {
 			props.setValue(PluginUtils.KEY_SEMESTER, form.getSemesterField().getText());
 		}
+	}
+
+	@Override
+	public @NotNull ActionUpdateThread getActionUpdateThread() {
+		return ActionUpdateThread.BGT;
 	}
 }


### PR DESCRIPTION
`ActionUpdateThread.OLD_EDT` is being deprecated, and errors will pop up when running IntelliJ (even when the plugin is not actively used). Here is the error message:

```
com.intellij.diagnostic.PluginException: `ActionUpdateThread.OLD_EDT` is deprecated and going to be removed soon. 'edu.berkeley.cs61b.plugin.CheckStyleAction' must override `getActionUpdateThread()` and chose EDT or BGT. See ActionUpdateThread javadoc. [Plugin: edu.berkeley.cs61b.plugin]
	at com.intellij.diagnostic.PluginProblemReporterImpl.createPluginExceptionByClass(PluginProblemReporterImpl.java:23)
	at com.intellij.diagnostic.PluginException.createByClass(PluginException.java:90)
	at com.intellij.diagnostic.PluginException.reportDeprecatedUsage(PluginException.java:125)
	at com.intellij.openapi.actionSystem.ActionUpdateThreadAware.getActionUpdateThread(ActionUpdateThreadAware.java:21)
	at com.intellij.openapi.actionSystem.AnAction.getActionUpdateThread(AnAction.java:201)
```
Some points of concern:
- I don't know how to test the plugin locally, so I did not do any testing.
- `ActionUpdateThread.BGT` *should* be fine for our use cases?
- I was unable to find any documentation on `ActionUpdateThread` and which version it was being deprecated from. There is a small but unlikely (in my opinion) chance that this will break the plugin on older versions of IntelliJ.